### PR TITLE
Fix: Apply overflow-hidden to sidebar inner container

### DIFF
--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -55,7 +55,7 @@ export function AppSidebar() {
   const { user } = useUser()
 
   return (
-    <Sidebar variant="floating" className="border-0 shadow-2xl [&>div>div]:overflow-hidden">
+    <Sidebar variant="floating" className="border-0 shadow-2xl">
       <SidebarHeader className="border-b border-border/20 px-4 py-4">
         <div className="flex items-center gap-3">
           <motion.div 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -244,7 +244,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm overflow-hidden"
         >
           {children}
         </div>


### PR DESCRIPTION
The floating sidebar had an issue where child elements, specifically the header and footer with their own borders, were not being clipped by the parent's rounded corners. This resulted in visually "sharp corners sticking out".

This commit addresses the issue by adding the `overflow-hidden` Tailwind CSS class directly to the `div` with `data-slot="sidebar-inner"` within the generic `Sidebar` component (`components/ui/sidebar.tsx`). This `div` is the element that receives the `rounded-lg` class for the floating variant.

Additionally, a redundant `[&>div>div]:overflow-hidden` class was removed from the `AppSidebar` component (`components/layout/app-sidebar.tsx`) as the fix is now handled at a more appropriate and effective level in the UI component.