### PR TITLE
feat: add nova splash loading screen

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import { Inter } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { Providers } from "./providers";
@@ -44,6 +45,25 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="en" suppressHydrationWarning>
         <body className={`${inter.variable} font-sans antialiased`}>
+          <div
+            id="nova-splash"
+            aria-hidden="true"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-gradient-to-br from-slate-50 via-slate-100 to-white opacity-100 transition-opacity duration-500"
+          >
+            <div className="flex flex-col items-center gap-6">
+              <Image
+                src="/nova-logo.svg"
+                alt="Nova"
+                width={96}
+                height={96}
+                priority
+                className="h-24 w-24"
+              />
+              <p className="text-sm font-medium tracking-[0.3em] text-slate-500">
+                JOURNALING REIMAGINED
+              </p>
+            </div>
+          </div>
           <Providers>{children}</Providers>
         </body>
       </html>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,17 @@
+import Image from "next/image";
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gradient-to-br from-slate-50 via-slate-100 to-white">
+      <Image
+        src="/nova-logo.svg"
+        alt="Nova"
+        width={96}
+        height={96}
+        priority
+        className="h-24 w-24"
+      />
+      <p className="text-sm font-medium tracking-[0.3em] text-slate-500">JOURNALING REIMAGINED</p>
+    </div>
+  );
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,10 +1,10 @@
-'use client'
+"use client";
 
-import * as React from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { ThemeProvider as NextThemesProvider } from 'next-themes'
-import { Toaster } from 'sonner'
+import * as React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { Toaster } from "sonner";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = React.useState(
@@ -16,8 +16,36 @@ export function Providers({ children }: { children: React.ReactNode }) {
             retry: 1,
           },
         },
-      }),
-  )
+      })
+  );
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const splash = document.getElementById("nova-splash");
+
+    if (!splash) {
+      return;
+    }
+
+    splash.classList.remove("opacity-100");
+    splash.classList.add("opacity-0");
+
+    const removeSplash = () => {
+      splash.remove();
+    };
+
+    splash.addEventListener("transitionend", removeSplash, { once: true });
+
+    const fallbackTimeout = window.setTimeout(removeSplash, 700);
+
+    return () => {
+      splash.removeEventListener("transitionend", removeSplash);
+      window.clearTimeout(fallbackTimeout);
+    };
+  }, []);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -35,9 +63,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
           duration={4000}
         />
       </NextThemesProvider>
-      {process.env.NODE_ENV !== 'production' ? (
+      {process.env.NODE_ENV !== "production" ? (
         <ReactQueryDevtools initialIsOpen={false} />
       ) : null}
     </QueryClientProvider>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add a root-level loading UI that centers the Nova logo while content loads
- style the splash with the default light gradient and supporting tagline for offline-friendly polish

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e6b54e41a48330aa04b70fb7011ae9