### PR TITLE
fix: enforce canonical site host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+v8-compile-cache-*/
 
 # debug
 npm-debug.log*

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,13 +30,9 @@ export const metadata: Metadata = {
   creator: siteName,
   publisher: siteName,
   category: "Productivity",
-  alternates: {
-    canonical: siteUrl,
-  },
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: siteUrl,
     title: "Nova - AI Personal Journal",
     description: siteDescription,
     siteName,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,9 +63,9 @@ export const metadata: Metadata = {
     googleBot: {
       index: true,
       follow: true,
-      maxImagePreview: "large",
-      maxSnippet: -1,
-      maxVideoPreview: -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
     },
   },
   icons: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,14 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { Inter } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
+import {
+  siteDescription,
+  siteKeywords,
+  siteName,
+  siteOgImage,
+  siteTwitterHandle,
+  siteUrl,
+} from "@/shared/lib/site-metadata";
 import { Providers } from "./providers";
 import "./globals.css";
 
@@ -11,9 +19,55 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Nova - AI Personal Journal",
-  description:
-    "A minimalist journaling app with AI-powered insights for personal growth and reflection",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: "Nova - AI Personal Journal",
+    template: "%s | Nova",
+  },
+  description: siteDescription,
+  keywords: siteKeywords,
+  authors: [{ name: siteName }],
+  creator: siteName,
+  publisher: siteName,
+  category: "Productivity",
+  alternates: {
+    canonical: siteUrl,
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: siteUrl,
+    title: "Nova - AI Personal Journal",
+    description: siteDescription,
+    siteName,
+    images: [
+      {
+        url: siteOgImage,
+        width: 1200,
+        height: 630,
+        alt: "Nova journaling application preview",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    creator: siteTwitterHandle,
+    site: siteTwitterHandle,
+    title: "Nova - AI Personal Journal",
+    description: siteDescription,
+    images: [siteOgImage],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      maxImagePreview: "large",
+      maxSnippet: -1,
+      maxVideoPreview: -1,
+    },
+  },
   icons: {
     icon: [
       { url: "/favicon-16x16.png?v=2", sizes: "16x16", type: "image/png" },

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import Script from "next/script";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@clerk/nextjs";
+import { useTheme } from "next-themes";
+import { PenLine, Brain, Shield } from "lucide-react";
+import { Button } from "@/components/shared/ui/button";
+import {
+  siteDescription,
+  siteName,
+  siteOgImage,
+  siteUrl,
+} from "@/shared/lib/site-metadata";
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: siteName,
+  url: siteUrl,
+  description: siteDescription,
+  image: siteOgImage,
+  applicationCategory: "LifestyleApplication",
+  operatingSystem: "Web",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  potentialAction: {
+    "@type": "RegisterAction",
+    target: `${siteUrl}/sign-up`,
+  },
+};
+
+const HomePageClient = () => {
+  const { userId } = useAuth();
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (userId) {
+      router.push("/dashboard");
+    }
+  }, [userId, router]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-slate-100 to-slate-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800">
+      <Script
+        id="nova-homepage-structured-data"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <div className="container mx-auto px-4 py-16">
+        <nav className="flex justify-between items-center mb-16">
+          <div className="flex items-center gap-3">
+            {mounted && (
+              <Image
+                src={
+                  resolvedTheme === "dark"
+                    ? "/nova-logo-dark-mode.svg"
+                    : "/nova-logo.svg"
+                }
+                alt="Nova Logo"
+                width={36}
+                height={36}
+                className="h-9 w-9"
+              />
+            )}
+            <span className="text-[26px] font-semibold leading-none text-primary">
+              Nova
+            </span>
+          </div>
+          <div className="flex gap-4">
+            <Button variant="ghost" asChild>
+              <Link href="/sign-in">Sign In</Link>
+            </Button>
+            <Button asChild>
+              <Link href="/sign-up">Get Started</Link>
+            </Button>
+          </div>
+        </nav>
+
+        <main className="max-w-6xl mx-auto">
+          <div className="text-center mb-16 space-y-6">
+            <h1 className="text-5xl md:text-6xl font-bold tracking-tight">
+              Your AI-Powered
+              <span className="block text-primary">Personal Journal</span>
+            </h1>
+            <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+              Nova is your intelligent companion for self-reflection, personal
+              growth, and meaningful insights. Journal your thoughts and receive
+              personalized guidance from an AI that understands you.
+            </p>
+            <div className="flex gap-4 justify-center pt-4">
+              <Button size="lg" asChild>
+                <Link href="/sign-up">Start Journaling Free</Link>
+              </Button>
+              <Button size="lg" variant="outline" asChild>
+                <Link href="#features">Learn More</Link>
+              </Button>
+            </div>
+          </div>
+
+          <div id="features" className="grid md:grid-cols-3 gap-8 pt-16">
+            <div className="bg-card p-8 rounded-lg shadow-sm">
+              <div className="mb-4">
+                <PenLine className="h-10 w-10 text-primary" />
+              </div>
+              <h3 className="text-xl font-semibold mb-2">Guided Journaling</h3>
+              <p className="text-muted-foreground">
+                Daily prompts designed to unlock deep reflection and
+                self-awareness. Write at your own pace with questions that
+                matter.
+              </p>
+            </div>
+
+            <div className="bg-card p-8 rounded-lg shadow-sm">
+              <div className="mb-4">
+                <Brain className="h-10 w-10 text-primary" />
+              </div>
+              <h3 className="text-xl font-semibold mb-2">AI Insights</h3>
+              <p className="text-muted-foreground">
+                Nova learns from your entries to provide personalized insights,
+                helping you understand patterns and grow.
+              </p>
+            </div>
+
+            <div className="bg-card p-8 rounded-lg shadow-sm">
+              <div className="mb-4">
+                <Shield className="h-10 w-10 text-primary" />
+              </div>
+              <h3 className="text-xl font-semibold mb-2">Private & Secure</h3>
+              <p className="text-muted-foreground">
+                Your thoughts are sacred. All entries are encrypted and private.
+                You have complete control over your data.
+              </p>
+            </div>
+          </div>
+
+          <div className="text-center mt-20 pb-8">
+            <h2 className="text-3xl font-semibold mb-4">
+              Begin Your Journey of Self-Discovery
+            </h2>
+            <p className="text-muted-foreground mb-8 max-w-xl mx-auto">
+              Join thousands who have found clarity, purpose, and growth through
+              daily reflection with Nova.
+            </p>
+            <Button size="lg" asChild>
+              <Link href="/sign-up">Create Your Free Account</Link>
+            </Button>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default HomePageClient;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,35 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/shared/ui/button";
 import { PenLine, Brain, Shield } from "lucide-react";
 import Image from "next/image";
+import Script from "next/script";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
+import {
+  siteDescription,
+  siteName,
+  siteOgImage,
+  siteUrl,
+} from "@/shared/lib/site-metadata";
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: siteName,
+  url: siteUrl,
+  description: siteDescription,
+  image: siteOgImage,
+  applicationCategory: "LifestyleApplication",
+  operatingSystem: "Web",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  potentialAction: {
+    "@type": "RegisterAction",
+    target: `${siteUrl}/sign-up`,
+  },
+};
 
 export default function Home() {
   const { userId } = useAuth();
@@ -27,6 +54,12 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-slate-100 to-slate-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800">
+      <Script
+        id="nova-homepage-structured-data"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <div className="container mx-auto px-4 py-16">
         <nav className="flex justify-between items-center mb-16">
           <div className="flex items-center gap-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,159 +1,16 @@
-"use client";
+import type { Metadata } from "next";
+import HomePageClient from "./page-client";
+import { siteUrl } from "@/shared/lib/site-metadata";
 
-import Link from "next/link";
-import { useAuth } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/shared/ui/button";
-import { PenLine, Brain, Shield } from "lucide-react";
-import Image from "next/image";
-import Script from "next/script";
-import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
-import {
-  siteDescription,
-  siteName,
-  siteOgImage,
-  siteUrl,
-} from "@/shared/lib/site-metadata";
-
-const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  name: siteName,
-  url: siteUrl,
-  description: siteDescription,
-  image: siteOgImage,
-  applicationCategory: "LifestyleApplication",
-  operatingSystem: "Web",
-  offers: {
-    "@type": "Offer",
-    price: "0",
-    priceCurrency: "USD",
+export const metadata: Metadata = {
+  alternates: {
+    canonical: siteUrl,
   },
-  potentialAction: {
-    "@type": "RegisterAction",
-    target: `${siteUrl}/sign-up`,
+  openGraph: {
+    url: siteUrl,
   },
 };
 
 export default function Home() {
-  const { userId } = useAuth();
-  const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  const router = useRouter();
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (userId) {
-      router.push("/dashboard");
-    }
-  }, [userId, router]);
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-slate-100 to-slate-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800">
-      <Script
-        id="nova-homepage-structured-data"
-        type="application/ld+json"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-      />
-      <div className="container mx-auto px-4 py-16">
-        <nav className="flex justify-between items-center mb-16">
-          <div className="flex items-center gap-3">
-            {mounted && (
-              <Image
-                src={resolvedTheme === 'dark' ? '/nova-logo-dark-mode.svg' : '/nova-logo.svg'}
-                alt="Nova Logo"
-                width={36}
-                height={36}
-                className="h-9 w-9"
-              />
-            )}
-            <span className="text-[26px] font-semibold leading-none text-primary">Nova</span>
-          </div>
-          <div className="flex gap-4">
-            <Button variant="ghost" asChild>
-              <Link href="/sign-in">Sign In</Link>
-            </Button>
-            <Button asChild>
-              <Link href="/sign-up">Get Started</Link>
-            </Button>
-          </div>
-        </nav>
-
-        <main className="max-w-6xl mx-auto">
-          <div className="text-center mb-16 space-y-6">
-            <h1 className="text-5xl md:text-6xl font-bold tracking-tight">
-              Your AI-Powered
-              <span className="block text-primary">Personal Journal</span>
-            </h1>
-            <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Nova is your intelligent companion for self-reflection, personal growth, 
-              and meaningful insights. Journal your thoughts and receive personalized 
-              guidance from an AI that understands you.
-            </p>
-            <div className="flex gap-4 justify-center pt-4">
-              <Button size="lg" asChild>
-                <Link href="/sign-up">Start Journaling Free</Link>
-              </Button>
-              <Button size="lg" variant="outline" asChild>
-                <Link href="#features">Learn More</Link>
-              </Button>
-            </div>
-          </div>
-
-          <div id="features" className="grid md:grid-cols-3 gap-8 pt-16">
-            <div className="bg-card p-8 rounded-lg shadow-sm">
-              <div className="mb-4">
-                <PenLine className="h-10 w-10 text-primary" />
-              </div>
-              <h3 className="text-xl font-semibold mb-2">Guided Journaling</h3>
-              <p className="text-muted-foreground">
-                Daily prompts designed to unlock deep reflection and self-awareness. 
-                Write at your own pace with questions that matter.
-              </p>
-            </div>
-
-            <div className="bg-card p-8 rounded-lg shadow-sm">
-              <div className="mb-4">
-                <Brain className="h-10 w-10 text-primary" />
-              </div>
-              <h3 className="text-xl font-semibold mb-2">AI Insights</h3>
-              <p className="text-muted-foreground">
-                Nova learns from your entries to provide personalized insights, 
-                helping you understand patterns and grow.
-              </p>
-            </div>
-
-            <div className="bg-card p-8 rounded-lg shadow-sm">
-              <div className="mb-4">
-                <Shield className="h-10 w-10 text-primary" />
-              </div>
-              <h3 className="text-xl font-semibold mb-2">Private & Secure</h3>
-              <p className="text-muted-foreground">
-                Your thoughts are sacred. All entries are encrypted and private. 
-                You have complete control over your data.
-              </p>
-            </div>
-          </div>
-
-          <div className="text-center mt-20 pb-8">
-            <h2 className="text-3xl font-semibold mb-4">
-              Begin Your Journey of Self-Discovery
-            </h2>
-            <p className="text-muted-foreground mb-8 max-w-xl mx-auto">
-              Join thousands who have found clarity, purpose, and growth through 
-              daily reflection with Nova.
-            </p>
-            <Button size="lg" asChild>
-              <Link href="/sign-up">Create Your Free Account</Link>
-            </Button>
-          </div>
-        </main>
-      </div>
-    </div>
-  );
+  return <HomePageClient />;
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/shared/lib/site-metadata";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/shared/lib/site-metadata";
+
+const publicRoutes = ["", "/sign-in", "/sign-up"];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return publicRoutes.map((path) => ({
+    url: `${siteUrl}${path}`,
+    lastModified,
+    changeFrequency: "monthly",
+    priority: path === "" ? 1 : 0.6,
+  }));
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,15 +1,15 @@
 import type { MetadataRoute } from "next";
 import { siteUrl } from "@/shared/lib/site-metadata";
 
-const publicRoutes = ["", "/sign-in", "/sign-up"];
+const marketingRoutes = [""]; // Only expose the canonical landing page
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();
 
-  return publicRoutes.map((path) => ({
+  return marketingRoutes.map((path) => ({
     url: `${siteUrl}${path}`,
     lastModified,
     changeFrequency: "monthly",
-    priority: path === "" ? 1 : 0.6,
+    priority: 1,
   }));
 }

--- a/src/shared/lib/site-metadata.ts
+++ b/src/shared/lib/site-metadata.ts
@@ -1,0 +1,71 @@
+const FALLBACK_SITE_URL = "https://www.nova-plus.app";
+const FALLBACK_URL = new URL(FALLBACK_SITE_URL);
+const CANONICAL_HOSTNAME = FALLBACK_URL.hostname;
+const CANONICAL_ROOT_HOSTNAME = CANONICAL_HOSTNAME.replace(/^www\./, "");
+const CANONICAL_HOST_ROOTS = new Set([
+  CANONICAL_ROOT_HOSTNAME,
+  "nova-journal.app",
+]);
+
+function normalizeUrl(url: string | undefined) {
+  if (!url) {
+    return FALLBACK_SITE_URL;
+  }
+
+  const trimmed = url.trim();
+
+  if (!trimmed) {
+    return FALLBACK_SITE_URL;
+  }
+
+  const hasProtocol = /^https?:\/\//i.test(trimmed);
+  const withProtocol = hasProtocol ? trimmed : `https://${trimmed}`;
+
+  try {
+    const normalized = new URL(withProtocol);
+    const hostnameRoot = normalized.hostname.replace(/^www\./, "");
+
+    if (CANONICAL_HOST_ROOTS.has(hostnameRoot)) {
+      normalized.hostname = CANONICAL_HOSTNAME;
+    }
+
+    normalized.protocol = "https:";
+
+    const base = normalized.origin;
+
+    if (normalized.pathname === "/") {
+      return base;
+    }
+
+    const cleanedPath = normalized.pathname.replace(/\/$/, "");
+    const search = normalized.search ?? "";
+    const hash = normalized.hash ?? "";
+
+    return `${base}${cleanedPath}${search}${hash}`;
+  } catch {
+    return FALLBACK_SITE_URL;
+  }
+}
+
+export const siteUrl = normalizeUrl(
+  process.env.NEXT_PUBLIC_SITE_URL ?? process.env.VERCEL_URL,
+);
+
+export const siteName = "Nova";
+
+export const siteDescription =
+  "Nova is an AI-powered journaling companion that helps you reflect, gain insights, and grow every day.";
+
+export const siteKeywords = [
+  "AI journaling app",
+  "personal growth journal",
+  "daily reflection prompts",
+  "mindfulness journal",
+  "secure digital diary",
+  "mental wellness",
+  "guided journaling",
+];
+
+export const siteTwitterHandle = "@novajournal";
+
+export const siteOgImage = `${siteUrl}/nova-logo-w-bg.svg`;


### PR DESCRIPTION
## Summary
- ensure the shared site metadata normalizes any configured domain—including nova-journal.app aliases—to the canonical https://www.nova-plus.app host
- prevent accidental commits of Node's v8 compile cache directories

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68edc29a45bc83308342c311efbb8335