### PR TITLE
fix: keep mobile sidebar open while interacting with user menu

### DIFF
--- a/src/components/shared/layout/app-sidebar.tsx
+++ b/src/components/shared/layout/app-sidebar.tsx
@@ -156,7 +156,9 @@ export function AppSidebar() {
             appearance={{
               elements: {
                 avatarBox: "h-9 w-9",
-                userButtonPopoverCard: "shadow-xl",
+                userButtonPopover: "prevent-mobile-sheet-close",
+                userButtonPopoverCard: "shadow-xl prevent-mobile-sheet-close",
+                userButtonPopoverFooter: "prevent-mobile-sheet-close",
               },
             }}
           />

--- a/src/components/shared/ui/sidebar.tsx
+++ b/src/components/shared/ui/sidebar.tsx
@@ -10,6 +10,10 @@ import { cn } from "@/shared/lib/utils"
 import { Button } from "@/components/shared/ui/button"
 import { Input } from "@/components/shared/ui/input"
 import { Separator } from "@/components/shared/ui/separator"
+import type {
+  InteractionOutsideEvent,
+  PointerDownOutsideEvent,
+} from "@radix-ui/react-dismissable-layer"
 import {
   Sheet,
   SheetContent,
@@ -164,6 +168,31 @@ function Sidebar({
   collapsible?: "offcanvas" | "icon" | "none"
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+  const handlePreventClose = React.useCallback((target: EventTarget | null) => {
+    if (!(target instanceof Element)) {
+      return false
+    }
+
+    return Boolean(target.closest(".prevent-mobile-sheet-close"))
+  }, [])
+
+  const handlePointerDownOutside = React.useCallback(
+    (event: PointerDownOutsideEvent) => {
+      if (handlePreventClose(event.detail.originalEvent.target)) {
+        event.preventDefault()
+      }
+    },
+    [handlePreventClose]
+  )
+
+  const handleInteractOutside = React.useCallback(
+    (event: InteractionOutsideEvent) => {
+      if (handlePreventClose(event.detail.originalEvent.target)) {
+        event.preventDefault()
+      }
+    },
+    [handlePreventClose]
+  )
 
   if (collapsible === "none") {
     return (
@@ -194,6 +223,8 @@ function Sidebar({
             } as React.CSSProperties
           }
           side={side}
+          onPointerDownOutside={handlePointerDownOutside}
+          onInteractOutside={handleInteractOutside}
         >
           <SheetHeader className="sr-only">
             <SheetTitle>Sidebar</SheetTitle>


### PR DESCRIPTION
## Summary
- prevent the mobile sidebar sheet from closing when interacting with the Clerk user button popover
- tag Clerk popover elements so pointer events from the popover are ignored by the sheet close handler

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f00f4ee3508330aa853397ef1c996b