### PR TITLE
fix: guard mobile sidebar dismiss for exempt popovers

### DIFF
--- a/src/components/shared/layout/app-sidebar.tsx
+++ b/src/components/shared/layout/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SIDEBAR_MOBILE_POPOVER_EXEMPT_CLASS,
 } from "@/components/shared/ui/sidebar";
 import { UserButton, useUser } from "@clerk/nextjs";
 import Link from "next/link";
@@ -156,7 +157,13 @@ export function AppSidebar() {
             appearance={{
               elements: {
                 avatarBox: "h-9 w-9",
-                userButtonPopoverCard: "shadow-xl",
+                userButtonPopover: cn(
+                  "relative z-[70]",
+                  SIDEBAR_MOBILE_POPOVER_EXEMPT_CLASS,
+                ),
+                userButtonPopoverCard: "relative z-[70] shadow-xl",
+                userButtonPopoverMain: "relative z-[70]",
+                userButtonPopoverFooter: "relative z-[70]",
               },
             }}
           />

--- a/src/components/shared/ui/sidebar.tsx
+++ b/src/components/shared/ui/sidebar.tsx
@@ -31,6 +31,8 @@ const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+export const SIDEBAR_MOBILE_POPOVER_EXEMPT_CLASS =
+  "sidebar-mobile-interaction-exempt"
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed"
@@ -181,6 +183,36 @@ function Sidebar({
   }
 
   if (isMobile) {
+    const preventMobileDismiss = (
+      event: Parameters<
+        NonNullable<React.ComponentProps<typeof SheetContent>["onInteractOutside"]>
+      >[0]
+    ) => {
+      const originalEvent = (event as CustomEvent<{ originalEvent?: Event }>).detail
+        ?.originalEvent
+
+      const eventTargets = (
+        (typeof originalEvent?.composedPath === "function"
+          ? originalEvent?.composedPath()
+          : []) ?? []
+      ).concat(
+        originalEvent?.target ? [originalEvent.target] : [],
+        event.target ? [event.target] : []
+      )
+
+      const interactedWithExemptPopover = eventTargets.some((target) => {
+        if (!(target instanceof Element)) {
+          return false
+        }
+
+        return target.closest(`.${SIDEBAR_MOBILE_POPOVER_EXEMPT_CLASS}`)
+      })
+
+      if (interactedWithExemptPopover) {
+        event.preventDefault()
+      }
+    }
+
     return (
       <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
         <SheetContent
@@ -194,6 +226,8 @@ function Sidebar({
             } as React.CSSProperties
           }
           side={side}
+          onPointerDownOutside={preventMobileDismiss}
+          onInteractOutside={preventMobileDismiss}
         >
           <SheetHeader className="sr-only">
             <SheetTitle>Sidebar</SheetTitle>


### PR DESCRIPTION
## Summary
- inspect the full composed path from outside interactions so exempted popovers keep the mobile sheet open
- restore the modal sidebar sheet configuration so the overlay continues to intercept taps on the page background

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f00f4ee3508330aa853397ef1c996b