### PR TITLE
fix: restore pointer access for mobile sidebar popovers

### DIFF
--- a/src/components/shared/layout/app-sidebar.tsx
+++ b/src/components/shared/layout/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SIDEBAR_MOBILE_POPOVER_EXEMPT_CLASS,
 } from "@/components/shared/ui/sidebar";
 import { UserButton, useUser } from "@clerk/nextjs";
 import Link from "next/link";
@@ -156,7 +157,13 @@ export function AppSidebar() {
             appearance={{
               elements: {
                 avatarBox: "h-9 w-9",
-                userButtonPopoverCard: "shadow-xl",
+                userButtonPopover: cn(
+                  "relative z-[70]",
+                  SIDEBAR_MOBILE_POPOVER_EXEMPT_CLASS,
+                ),
+                userButtonPopoverCard: "relative z-[70] shadow-xl",
+                userButtonPopoverMain: "relative z-[70]",
+                userButtonPopoverFooter: "relative z-[70]",
               },
             }}
           />


### PR DESCRIPTION
## Summary
- allow the mobile sidebar sheet to keep outside pointer events enabled so Clerk popovers can receive taps
- rely on the existing interactOutside guard to keep exempt popovers from dismissing the sheet without cancelling their pointer events

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f00f4ee3508330aa853397ef1c996b