### PR TITLE
feat: add web app manifest

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,7 @@ export const metadata: Metadata = {
   creator: siteName,
   publisher: siteName,
   category: "Productivity",
+  themeColor: "#000000",
   openGraph: {
     type: "website",
     locale: "en_US",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,6 +73,7 @@ export const metadata: Metadata = {
       },
     ],
   },
+  manifest: "/manifest.webmanifest",
 };
 
 export default function RootLayout({

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,63 @@
+import type { MetadataRoute } from "next";
+
+import {
+  siteDescription,
+  siteName,
+  siteUrl,
+} from "@/shared/lib/site-metadata";
+
+const THEME_COLOR = "#0f172a";
+const BACKGROUND_COLOR = "#ffffff";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    id: siteUrl,
+    name: siteName,
+    short_name: "Nova",
+    description: siteDescription,
+    lang: "en",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    orientation: "portrait",
+    background_color: BACKGROUND_COLOR,
+    theme_color: THEME_COLOR,
+    prefer_related_applications: false,
+    icons: [
+      {
+        src: "/android-chrome-192x192.png?v=2",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/android-chrome-512x512.png?v=2",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/apple-touch-icon.png?v=2",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+    screenshots: [
+      {
+        src: "/nova-logo-w-bg.svg",
+        sizes: "1200x630",
+        type: "image/svg+xml",
+      },
+    ],
+    categories: ["productivity", "lifestyle"],
+    shortcuts: [
+      {
+        name: "Start journaling",
+        short_name: "Journal",
+        description: "Open Nova to create a new journal entry",
+        url: "/",
+      },
+    ],
+  };
+}

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -28,7 +28,7 @@ export default function manifest(): MetadataRoute.Manifest {
         src: "/nova-logo.svg",
         sizes: "any",
         type: "image/svg+xml",
-        purpose: "any maskable",
+        purpose: "maskable",
       },
       {
         src: "/android-chrome-192x192.png?v=2",

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -6,7 +6,7 @@ import {
   siteUrl,
 } from "@/shared/lib/site-metadata";
 
-const THEME_COLOR = "#0f172a";
+const THEME_COLOR = "#000000";
 const BACKGROUND_COLOR = "#ffffff";
 
 export default function manifest(): MetadataRoute.Manifest {
@@ -24,6 +24,12 @@ export default function manifest(): MetadataRoute.Manifest {
     theme_color: THEME_COLOR,
     prefer_related_applications: false,
     icons: [
+      {
+        src: "/nova-logo.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any maskable",
+      },
       {
         src: "/android-chrome-192x192.png?v=2",
         sizes: "192x192",


### PR DESCRIPTION
## Summary
- add a Next.js manifest route configured with Nova branding for PWA install support
- register the manifest with the root layout metadata so browsers can discover it

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f5245b4ce48330a40a30bef300716b