### PR TITLE
fix: use isAuthenticated in middleware redirect

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
-import { auth } from "@clerk/nextjs/server";
 import { PenLine, Brain, Shield } from "lucide-react";
 import { Button } from "@/components/shared/ui/button";
 import {
@@ -79,13 +77,7 @@ const testimonials = [
   },
 ] as const;
 
-export default async function Home() {
-  const { userId } = await auth();
-
-  if (userId) {
-    redirect("/dashboard");
-  }
-
+export default function Home() {
   return (
     <div className="relative min-h-screen bg-background text-foreground antialiased">
       <div

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isProtectedRoute = createRouteMatcher([
   "/dashboard(.*)",
@@ -9,9 +10,20 @@ const isProtectedRoute = createRouteMatcher([
 ]);
 
 export default clerkMiddleware(async (auth, req) => {
+  if (req.nextUrl.pathname === "/") {
+    const { isAuthenticated } = await auth();
+    if (isAuthenticated) {
+      const url = req.nextUrl.clone();
+      url.pathname = "/dashboard";
+      return NextResponse.redirect(url);
+    }
+  }
+
   if (isProtectedRoute(req)) {
     await auth.protect();
   }
+
+  return NextResponse.next();
 });
 
 export const config = {


### PR DESCRIPTION
## Summary
- switch the root redirect check in the Clerk middleware to use `isAuthenticated`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6887c882c8330a6c8c264e4c91bdf