### PR TITLE
fix: narrow mobile sidebar rail width

### DIFF
--- a/src/components/shared/ui/sidebar.tsx
+++ b/src/components/shared/ui/sidebar.tsx
@@ -301,7 +301,7 @@ function SidebarRail({
         onClick={toggleSidebar}
         title="Open Sidebar"
         className={cn(
-          "fixed inset-y-0 z-40 w-6 bg-transparent transition-opacity duration-150 ease-linear appearance-none focus-visible:outline-none focus-visible:ring-0 md:hidden",
+          "fixed inset-y-0 z-40 w-4 bg-transparent transition-opacity duration-150 ease-linear appearance-none focus-visible:outline-none focus-visible:ring-0 hover:bg-transparent focus:bg-transparent active:bg-transparent md:hidden",
           side === "left" ? "left-0" : "right-0",
           openMobile ? "pointer-events-none opacity-0" : "opacity-100",
           className
@@ -321,7 +321,7 @@ function SidebarRail({
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 bg-transparent transition-all ease-linear appearance-none focus-visible:outline-none focus-visible:ring-0 group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 bg-transparent transition-all ease-linear appearance-none focus-visible:outline-none focus-visible:ring-0 hover:bg-transparent focus:bg-transparent active:bg-transparent group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0",


### PR DESCRIPTION
## Summary
- reduce the tappable rail width on mobile sidebars so the keyboard no longer overlaps obvious gray bars
- ensure the rails stay transparent by explicitly clearing hover, focus, and active backgrounds on both mobile and desktop rails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fab1ef2f5c83308d6a4566a209ccfd