### PR TITLE
fix: remove unused Sparkles import from home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,6 @@ import {
   Shield,
   CalendarDays,
   Feather,
-  Sparkles,
 } from "lucide-react";
 import { Button } from "@/components/shared/ui/button";
 import {


### PR DESCRIPTION
## Summary
- remove the unused Sparkles icon import from the home page to satisfy lint rules

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163787a81883308e5618d69d8b345a)