### PR TITLE
Add Sky theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -265,6 +265,49 @@
   --sidebar-ring: oklch(0.70 0.12 145);
 }
 
+.sky {
+  /* Sky - Light and airy like clouds on a clear day */
+  --background: oklch(0.97 0.015 225);
+  --foreground: oklch(0.25 0.04 230);
+  --card: oklch(0.99 0.008 220);
+  --card-foreground: oklch(0.25 0.04 230);
+  --popover: oklch(0.99 0.008 220);
+  --popover-foreground: oklch(0.25 0.04 230);
+  --primary: oklch(0.55 0.14 230);
+  --primary-foreground: oklch(0.99 0.005 220);
+  --secondary: oklch(0.92 0.03 225);
+  --secondary-foreground: oklch(0.30 0.05 230);
+  --muted: oklch(0.94 0.02 225);
+  --muted-foreground: oklch(0.50 0.04 230);
+  --accent: oklch(0.88 0.06 210);
+  --accent-foreground: oklch(0.25 0.04 230);
+  --destructive: oklch(0.55 0.20 25);
+  --border: oklch(0.88 0.025 225);
+  --input: oklch(0.95 0.02 225);
+  --ring: oklch(0.55 0.14 230);
+
+  /* Accent colors - Bright sky tones */
+  --warm: oklch(0.60 0.12 230);
+  --glow: oklch(0.65 0.10 200);
+
+  /* Chart colors - Sky and cloud palette */
+  --chart-1: oklch(0.55 0.14 230);
+  --chart-2: oklch(0.65 0.10 200);
+  --chart-3: oklch(0.60 0.08 250);
+  --chart-4: oklch(0.70 0.06 180);
+  --chart-5: oklch(0.50 0.12 260);
+
+  /* Sidebar */
+  --sidebar: oklch(0.96 0.012 225);
+  --sidebar-foreground: oklch(0.25 0.04 230);
+  --sidebar-primary: oklch(0.55 0.14 230);
+  --sidebar-primary-foreground: oklch(0.99 0.005 220);
+  --sidebar-accent: oklch(0.90 0.04 220);
+  --sidebar-accent-foreground: oklch(0.25 0.04 230);
+  --sidebar-border: oklch(0.90 0.02 225);
+  --sidebar-ring: oklch(0.55 0.14 230);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -112,7 +112,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         attribute="class"
         defaultTheme="light"
         storageKey="nova-theme"
-        themes={["light", "sunset", "dark", "rose-pine", "evergreen"]}
+        themes={["light", "sunset", "dark", "rose-pine", "evergreen", "sky"]}
         enableSystem
         disableTransitionOnChange
       >

--- a/src/shared/lib/theme/config.ts
+++ b/src/shared/lib/theme/config.ts
@@ -1,7 +1,7 @@
-import { Flower2, Monitor, Moon, Sun, Sunset, TreePine } from "lucide-react";
+import { Cloud, Flower2, Monitor, Moon, Sun, Sunset, TreePine } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
-export type ThemeId = "light" | "sunset" | "dark" | "rose-pine" | "evergreen" | "system";
+export type ThemeId = "light" | "sunset" | "dark" | "rose-pine" | "evergreen" | "sky" | "system";
 
 export interface ThemeConfig {
   id: ThemeId;
@@ -35,6 +35,11 @@ const themeConfigs: Record<Exclude<ThemeId, "system">, ThemeConfig> = {
     label: "Evergreen",
     icon: TreePine,
   },
+  sky: {
+    id: "sky",
+    label: "Sky",
+    icon: Cloud,
+  },
 };
 
 const systemThemeConfig: ThemeConfig = {
@@ -49,5 +54,6 @@ export const themeList: ThemeConfig[] = [
   themeConfigs.dark,
   themeConfigs["rose-pine"],
   themeConfigs.evergreen,
+  themeConfigs.sky,
   systemThemeConfig,
 ];


### PR DESCRIPTION
## Summary
- Adds a new "Sky" theme - a light, airy theme inspired by a clear sky with clouds
- Uses sky blue hues (oklch ~225-230) for a fresh, calming aesthetic
- Light backgrounds evoke fluffy clouds, with gentle blue accents

## Changes
- `src/shared/lib/theme/config.ts`: Added sky theme type, config with Cloud icon
- `src/app/globals.css`: Added sky theme CSS variables
- `src/app/providers.tsx`: Added sky to themes array

## Test plan
- [ ] Run `pnpm dev` and select "Sky" from the theme toggle
- [ ] Verify all UI elements display correctly with the new theme
- [ ] Check both light and dark mode switching works